### PR TITLE
Debian support

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -6,4 +6,3 @@ elixir_version: v1.0.3
 # github url
 kerl_bin_github_url: http://github.com/yrashk/kerl/raw/master/kerl
 elixir_github_url: https://github.com/elixir-lang/elixir.git
-

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -54,8 +54,8 @@ galaxy_info:
   #  - 9.1
   #  - 9.1
   #  - 9.2
-  #- name: Ubuntu
-  #  versions:
+  - name: Ubuntu
+   versions:
   #  - all
   #  - lucid:10.04
   #  - maverick:10.10
@@ -65,7 +65,9 @@ galaxy_info:
   #  - quantal:12.10
   #  - raring:13.04
   #  - saucy:13.10
-  #  - trusty:14.04
+   - trusty:14.04
+   - vivid:15.04
+   - wily:15.10
   #- name: SLES
   #  versions:
   #  - all
@@ -107,4 +109,3 @@ dependencies: []
   # dependencies available via galaxy should be listed here.
   # Be sure to remove the '[]' above if you add dependencies
   # to this list.
-  

--- a/tasks/elixir.yml
+++ b/tasks/elixir.yml
@@ -8,4 +8,4 @@
   args:
     chdir: "{{elixir_build_dir}}"
     creates: "{{elixir_install_dir}}/elixir"
-
+    executable: /bin/bash

--- a/tasks/lib.yml
+++ b/tasks/lib.yml
@@ -1,7 +1,7 @@
 ---
 
-- name: install dependent packages
-  yum: name={{item}} state=present
+- name: install dependent packages for red hat derivative distros
+  yum: name={{item}} state=present update_cache=yes
   with_items:
     - git-core
     - curl
@@ -12,4 +12,18 @@
     - libselinux-python
     - ncurses-devel
     - openssl-devel
+  when: ansible_os_family == 'RedHat'
 
+- name: install dependent packages for debian derivative distros
+  apt: name={{item}} state=present update_cache=yes
+  with_items:
+    - git-core
+    - curl
+    - gcc
+    - libc6
+    - make
+    - autoconf
+    - libncurses5-dev
+    - openssl
+    - libssl-dev
+  when: ansible_os_family == 'Debian'


### PR DESCRIPTION
This commit introduces support for Ubuntu and Debian.
The only change required is installing a different set
of packages for each family of distros.

The update_cache option was enabled when installing packages
to fix an issue with installing on a fresh system.
